### PR TITLE
allow excluding dirs when fetching git/tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The branch to fetch from https://github.com/owncloud/core
 - `DOWNLOAD_URL`  
 Provide a tarball from a different location
 
+- `EXCLUDE`
+Exclude files/folders from being copied to the workspace. This is useful when testing apps that are included in the nightly tarballs. The exclude pattern uses rsync `--exclude` logic
+
 
 If `CORE_PATH` is not defined - the plugin assumes the workspace directory is nested two directories deeper in relation to the owncloud folder
 
@@ -56,6 +59,7 @@ DB_USERNAME        (owncloud)
 DB_PASSWORD        (owncloud)
 DB_HOST            (localhost:3306)
 DB_PREFIX          (oc_)
+EXCLUDE            
 ```
 ## Examples
 
@@ -102,6 +106,22 @@ services:
       - MYSQL_PASSWORD=secret
       - MYSQL_DATABASE=oc_db
       - MYSQL_ROOT_PASSWORD=secret
+```
+
+**Exclude folders/files from core**
+
+```
+workspace:
+  base: /var/www/owncloud
+  path: apps/my_app
+
+pipeline:
+  install-server:
+    image: owncloudci/core
+    pull: true
+    exclude:
+      - apps/notifications
+    version: daily-stable10-qa
 ```
 
 ## Issues, Feedback and Ideas


### PR DESCRIPTION
## Motivation

When using the tarball / (or a git branch) - the content of that tarball/branch would override, what is already present in the workspace dir.

This PR introduces a `exclude` parameter to allow for ignoring of some of these directories.

## Description
Behind the scenes, we now fetch the sourcecode into a temporary directory and then use rsync to move the core sourcecode to the final destination

`exclude` thus works to the way `--exclude` is handled by rsync

Fixes #7 