### PR TITLE
provide information on tarball/branch downloaded/cloned

### DIFF
--- a/rootfs/usr/sbin/plugin.sh
+++ b/rootfs/usr/sbin/plugin.sh
@@ -84,6 +84,11 @@ plugin_oc_from_tarball() {
   local dest_dir=${1}
   echo "\$ wget -qO- ${PLUGIN_DOWNLOAD_URL} | tar -${PLUGIN_EXTRACT_PARAMS} -C ${dest_dir} --strip 1"
   wget -qO- "${PLUGIN_DOWNLOAD_URL}" | tar -"${PLUGIN_EXTRACT_PARAMS}" -C "${dest_dir}" --strip 1
+  build_sha=$(grep OC_Build "${dest_dir}/version.php" | cut -d "'" -f2 | cut -d " " -f2)
+  build_date=$(grep OC_Build "${dest_dir}/version.php" | cut -d "'" -f2 | cut -d " " -f1)
+  build_version=$(grep OC_VersionString "${dest_dir}/version.php" | cut -d "'" -f2)
+  build_channel=$(grep OC_Channel "${dest_dir}/version.php" | cut -d "'" -f2)
+  echo "Fetched ${build_version} - channel: ${build_channel} - build at ${build_date} - SHA: ${build_sha}"
 }
 
 plugin_oc_from_git() {
@@ -103,6 +108,9 @@ plugin_oc_from_git() {
 
     echo "\$ git submodule update --init"
     git submodule update --init
+
+    echo "\$ git log --format=oneline -n 1"
+    git log --format=oneline -n 1
   popd
 }
 


### PR DESCRIPTION
## Motivation

As developer, I would like to know towards what git core state ( commit ) my own pull request is tested against.

This PR adds the following output:

When using a `git_reference`
```
$ git log --format=oneline -n 1
2544f460c1a0776bbbe8f456618d93f06a5386f5 Merge pull request #31032 from owncloud/stable10-discover-users
```

When using the pre-built tarballs
```
$ wget -qO- https://download.owncloud.org/community/owncloud-daily-stable10-qa.tar.bz2 | tar -xj -C /tmp/owncloud/ --strip 1
Fetched 10.0.8 alpha - channel: daily - build at 2018-04-05T22:25:45+00:00 - SHA: 9ec88864ba8e65cf976ffaf2bf002950682a00ea
```