### PR TITLE
Change default timeout waiting for database server

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ DB_USERNAME        (owncloud)
 DB_PASSWORD        (owncloud)
 DB_HOST            (localhost:3306)
 DB_PREFIX          (oc_)
-PLUGIN_DB_TIMEOUT  (45)
+DB_TIMEOUT         (120)
 EXCLUDE            
 ```
 ## Examples

--- a/rootfs/usr/sbin/plugin.sh
+++ b/rootfs/usr/sbin/plugin.sh
@@ -76,7 +76,7 @@ declare -x PLUGIN_DB_PREFIX
 [[ -z "${PLUGIN_DB_PREFIX}" ]] && PLUGIN_DB_PREFIX="oc_"
 
 declare -x PLUGIN_DB_TIMEOUT
-[[ -z "${PLUGIN_DB_TIMEOUT}" ]] && PLUGIN_DB_TIMEOUT="45"
+[[ -z "${PLUGIN_DB_TIMEOUT}" ]] && PLUGIN_DB_TIMEOUT="120"
 
 
 readonly PLUGIN_TMP_DIR="/tmp/owncloud/"


### PR DESCRIPTION
from 45 to 120 seconds.

We are getting times when it takes a while for the database docker image to load, then the database server to start, specially for Oracle.

It does not really hurt to have the default timeout longer here.