### PR TITLE
Change DB_TIMEOUT default from 120 to 600 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ DB_USERNAME        (owncloud)
 DB_PASSWORD        (owncloud)
 DB_HOST            (localhost:3306)
 DB_PREFIX          (oc_)
-DB_TIMEOUT         (120)
+DB_TIMEOUT         (600)
 EXCLUDE            
 ```
 ## Examples

--- a/rootfs/usr/sbin/plugin.sh
+++ b/rootfs/usr/sbin/plugin.sh
@@ -76,7 +76,7 @@ declare -x PLUGIN_DB_PREFIX
 [[ -z "${PLUGIN_DB_PREFIX}" ]] && PLUGIN_DB_PREFIX="oc_"
 
 declare -x PLUGIN_DB_TIMEOUT
-[[ -z "${PLUGIN_DB_TIMEOUT}" ]] && PLUGIN_DB_TIMEOUT="120"
+[[ -z "${PLUGIN_DB_TIMEOUT}" ]] && PLUGIN_DB_TIMEOUT="600"
 
 
 readonly PLUGIN_TMP_DIR="/tmp/owncloud/"


### PR DESCRIPTION
Like in core https://github.com/owncloud/core/pull/36579

## Description
The drone agents are sometimes taking "a long time" (tm) to pull docker images. In particular this is a problem when it takes a long time to pull the database image (mariadb, postgresql, oracle...). The `install-core` step waits 120 seconds for the database to become available. If the pull took more than 2 minutes, then we get a timeout in `install-core` and the pipeline fails. That means the whole build fails and it has to be started all over again. That is very annoying.

This is seen mostly first thing in the morning, when the autoscaler starts new drone agents. Specially if a lot of drone agents get started at a similar time, they seem to be slow to pull each docker image the first time. After that, they have the docker images cached, so later pulls of the docker images do not have this time delay.

Since we know there is a very variable delay here, set the timeout to a high value (10 minutes = 600 seconds). That will avoid annoying unnecessary fails, while still providing a reasonable time-to-failure in the rare case where the database really did fail on startup.
