### PR TITLE
Use PHP7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM owncloudci/php:7.1
+FROM owncloudci/php:7.2
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI core" \


### PR DESCRIPTION
PHP 7.1 is out of support. Early next year (hopefully) we will drop it. So we may as well bump the PHP version here now.

I suggest merge-release-deploy after https://github.com/owncloud-ci/php/pull/113 which will get the latest patch release of PHP 7.2 into the `owncloudci/php:7.2` docker image.