### PR TITLE
Use PHP 7.3

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM owncloudci/php:7.2
+FROM owncloudci/php:7.3
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI core" \


### PR DESCRIPTION
ownCloud core supports PHP 7.3 since 10.3 - https://doc.owncloud.com/server/admin_manual/release_notes.html#changes-in-10-3-0

We only ever run CI now with ownCloud core 10.5, 10.4.* and occasionally might run against 10.3.2 (but I expect not even that). This repo allows "auto" installing from a "release" tarball or a git reference. We no longer have any test environments where CI would have to use PHP 7.2 to do that install.

Move up to PHP 7.3 here. That will help CI that tries out newer PHP dependencies that would require dropping PHP 7.2.

(PHP 7.2 end-of-life is coming in 2020/12)