### PR TITLE
Add nodejs14 tools to owncloudci/core:latest

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -8,3 +8,16 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 
 ADD rootfs /
 ENTRYPOINT ["/usr/sbin/plugin.sh"]
+
+RUN apt-get update -y && \
+  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry && \
+  curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+  echo "deb https://deb.nodesource.com/node_14.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
+  apt-get update -y && \
+  apt-get install -y nodejs && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN npm install -g yarn npx --force


### PR DESCRIPTION
Fixes #29 

This will make `latest` the same as `nodejs14`

IMO that is now "a good thing" (see my explanation in the issue)