### PR TITLE
Download core tarballs from download.owncloud.com/server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ownCloud Core for CI pipelines. The plugin will fetch ownCloud core either from 
 The plugin requires either `VERSION`, `GIT_REFERENCE` or `DOWNLOAD_URL` to be defined. All other variables are optional
 
 - `VERSION`
-  The owncloud tarball version to fetch from https://download.owncloud.org/community/ or the daily or testing sub-directory
+  The owncloud tarball version to fetch from https://download.owncloud.com/server/ or the daily or testing sub-directory
 
 - `GIT_REFERENCE`
   The branch to fetch from https://github.com/owncloud/core
@@ -51,7 +51,7 @@ DOWNLOAD_URL
 CORE_DOWNLOAD_URL
 EXTRACT_PARAMS     (xj)
 DOWNLOAD_FILENAME  (owncloud-${PLUGIN_VERSION}.tar.bz2)
-DOWNLOAD_URL       (https://download.owncloud.org/community/${PLUGIN_DOWNLOAD_FILENAME})
+DOWNLOAD_URL       (https://download.owncloud.com/server/${PLUGIN_DOWNLOAD_FILENAME})
 GIT_REPOSITORY     (https://github.com/owncloud/core.git)
 INSTALL            (true)
 ADMIN_LOGIN        (admin)

--- a/latest/rootfs/usr/sbin/plugin.sh
+++ b/latest/rootfs/usr/sbin/plugin.sh
@@ -93,11 +93,11 @@ plugin_validate_url() {
 plugin_oc_from_tarball() {
   local dest_dir=${1}
   if  [[ -z "${PLUGIN_DOWNLOAD_URL}" ]]; then
-    PLUGIN_DOWNLOAD_URL="https://download.owncloud.org/community/daily/${PLUGIN_DOWNLOAD_FILENAME}"
+    PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/daily/${PLUGIN_DOWNLOAD_FILENAME}"
     if ! plugin_validate_url ${PLUGIN_DOWNLOAD_URL} ; then
-      PLUGIN_DOWNLOAD_URL="https://download.owncloud.org/community/testing/${PLUGIN_DOWNLOAD_FILENAME}"
+      PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/testing/${PLUGIN_DOWNLOAD_FILENAME}"
       if ! plugin_validate_url ${PLUGIN_DOWNLOAD_URL} ; then
-        PLUGIN_DOWNLOAD_URL="https://download.owncloud.org/community/${PLUGIN_DOWNLOAD_FILENAME}"
+        PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/${PLUGIN_DOWNLOAD_FILENAME}"
       fi
     fi
   fi

--- a/nodejs14/rootfs/usr/sbin/plugin.sh
+++ b/nodejs14/rootfs/usr/sbin/plugin.sh
@@ -93,11 +93,11 @@ plugin_validate_url() {
 plugin_oc_from_tarball() {
   local dest_dir=${1}
   if  [[ -z "${PLUGIN_DOWNLOAD_URL}" ]]; then
-    PLUGIN_DOWNLOAD_URL="https://download.owncloud.org/community/daily/${PLUGIN_DOWNLOAD_FILENAME}"
+    PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/daily/${PLUGIN_DOWNLOAD_FILENAME}"
     if ! plugin_validate_url ${PLUGIN_DOWNLOAD_URL} ; then
-      PLUGIN_DOWNLOAD_URL="https://download.owncloud.org/community/testing/${PLUGIN_DOWNLOAD_FILENAME}"
+      PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/testing/${PLUGIN_DOWNLOAD_FILENAME}"
       if ! plugin_validate_url ${PLUGIN_DOWNLOAD_URL} ; then
-        PLUGIN_DOWNLOAD_URL="https://download.owncloud.org/community/${PLUGIN_DOWNLOAD_FILENAME}"
+        PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/${PLUGIN_DOWNLOAD_FILENAME}"
       fi
     fi
   fi


### PR DESCRIPTION
The ownCloud core server tarballs are now found in download.owncloud.com/server

The old download.owncloud.org/community resources will be frozen for now. So get the tarballs from the new location, to ensure that we get the most up-to-date.