### PR TITLE
Releases are found in server/stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ownCloud Core for CI pipelines. The plugin will fetch ownCloud core either from 
 The plugin requires either `VERSION`, `GIT_REFERENCE` or `DOWNLOAD_URL` to be defined. All other variables are optional
 
 - `VERSION`
-  The owncloud tarball version to fetch from https://download.owncloud.com/server/ or the daily or testing sub-directory
+  The owncloud tarball version to fetch from https://download.owncloud.com/server/stable or daily or testing directory
 
 - `GIT_REFERENCE`
   The branch to fetch from https://github.com/owncloud/core
@@ -51,7 +51,7 @@ DOWNLOAD_URL
 CORE_DOWNLOAD_URL
 EXTRACT_PARAMS     (xj)
 DOWNLOAD_FILENAME  (owncloud-${PLUGIN_VERSION}.tar.bz2)
-DOWNLOAD_URL       (https://download.owncloud.com/server/${PLUGIN_DOWNLOAD_FILENAME})
+DOWNLOAD_URL       (https://download.owncloud.com/server/stable/${PLUGIN_DOWNLOAD_FILENAME})
 GIT_REPOSITORY     (https://github.com/owncloud/core.git)
 INSTALL            (true)
 ADMIN_LOGIN        (admin)

--- a/latest/rootfs/usr/sbin/plugin.sh
+++ b/latest/rootfs/usr/sbin/plugin.sh
@@ -97,7 +97,7 @@ plugin_oc_from_tarball() {
     if ! plugin_validate_url ${PLUGIN_DOWNLOAD_URL} ; then
       PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/testing/${PLUGIN_DOWNLOAD_FILENAME}"
       if ! plugin_validate_url ${PLUGIN_DOWNLOAD_URL} ; then
-        PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/${PLUGIN_DOWNLOAD_FILENAME}"
+        PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/stable/${PLUGIN_DOWNLOAD_FILENAME}"
       fi
     fi
   fi

--- a/nodejs14/rootfs/usr/sbin/plugin.sh
+++ b/nodejs14/rootfs/usr/sbin/plugin.sh
@@ -97,7 +97,7 @@ plugin_oc_from_tarball() {
     if ! plugin_validate_url ${PLUGIN_DOWNLOAD_URL} ; then
       PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/testing/${PLUGIN_DOWNLOAD_FILENAME}"
       if ! plugin_validate_url ${PLUGIN_DOWNLOAD_URL} ; then
-        PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/${PLUGIN_DOWNLOAD_FILENAME}"
+        PLUGIN_DOWNLOAD_URL="https://download.owncloud.com/server/stable/${PLUGIN_DOWNLOAD_FILENAME}"
       fi
     fi
   fi


### PR DESCRIPTION
The release tarball used to be in the top-level of https://download.owncloud.org/community

With the move to https://download.owncloud.com/server yesterday, the releases have been put in a subfolder:
https://download.owncloud.com/server/stable/

That keeps the top-level https://download.owncloud.com/server clean, with just the 3 directories, daily, stable and testing.

This PR updates the code for CI so that it will find the release tarballs in the correct new place.

This is a follow-on fix from PR #31 that was merged yesterday.