### PR TITLE
Use PHP 7.4 to install core

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM owncloudci/php:7.3@sha256:0e0c74db6abe0d685e13bd228ca229cd3dce0582bb4636eb799024b191384121
+FROM owncloudci/php:7.4@sha256:1675e85e86817533316faa7f42e7beca28555f983b383e24bc8b87e5846bfe19
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>"
 LABEL org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>"

--- a/nodejs14/Dockerfile.amd64
+++ b/nodejs14/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM owncloudci/php:7.4@sha256:dfdd491624384c3fe6b458d795c40b50708bfa9e1ac5c9246018cb07b57f54fb
+FROM owncloudci/php:7.4@sha256:1675e85e86817533316faa7f42e7beca28555f983b383e24bc8b87e5846bfe19
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>"
 LABEL org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>"


### PR DESCRIPTION
core master has dropped PHP 7.3. So we want to always use PHP 7.4 to run the install of core in CI.

Note: there might be some upgrade-testing repo/pipelines that may need to use an older PHP to install some very old ownCloud version. If that happens, then we can add an extra image here based on PHP 7.3 or earlier - but I am not sure if we will really need to do that.