### PR TITLE
Specify database-connection-string when installing with Oracle

### DIFF
--- a/latest/rootfs/usr/sbin/plugin.sh
+++ b/latest/rootfs/usr/sbin/plugin.sh
@@ -240,9 +240,15 @@ plugin_install_owncloud() {
         --data-dir=${PLUGIN_DATA_DIRECTORY} "
 
   if [[ "${PLUGIN_DB_TYPE}" != "sqlite" ]]; then
-    _occ_command+="--database-host=${PLUGIN_DB_HOST} \
-                   --database-user=${PLUGIN_DB_USERNAME} \
-                   --database-pass=${PLUGIN_DB_PASSWORD}"
+    if [[ "${PLUGIN_DB_TYPE}" != "oracle" ]]; then
+      _occ_command+="--database-host=${PLUGIN_DB_HOST} \
+                     --database-user=${PLUGIN_DB_USERNAME} \
+                     --database-pass=${PLUGIN_DB_PASSWORD}"
+    else
+      _occ_command+=" --database-connection-string=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=${PLUGIN_DB_TYPE})(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=XE))) \
+                     --database-user=${PLUGIN_DB_USERNAME} \
+                     --database-pass=${PLUGIN_DB_PASSWORD}"
+    fi
   fi
 
 

--- a/nodejs14/rootfs/usr/sbin/plugin.sh
+++ b/nodejs14/rootfs/usr/sbin/plugin.sh
@@ -240,9 +240,15 @@ plugin_install_owncloud() {
         --data-dir=${PLUGIN_DATA_DIRECTORY} "
 
   if [[ "${PLUGIN_DB_TYPE}" != "sqlite" ]]; then
-    _occ_command+="--database-host=${PLUGIN_DB_HOST} \
-                   --database-user=${PLUGIN_DB_USERNAME} \
-                   --database-pass=${PLUGIN_DB_PASSWORD}"
+    if [[ "${PLUGIN_DB_TYPE}" != "oracle" ]]; then
+      _occ_command+="--database-host=${PLUGIN_DB_HOST} \
+                     --database-user=${PLUGIN_DB_USERNAME} \
+                     --database-pass=${PLUGIN_DB_PASSWORD}"
+    else
+      _occ_command+=" --database-connection-string=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=${PLUGIN_DB_TYPE})(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=XE))) \
+                     --database-user=${PLUGIN_DB_USERNAME} \
+                     --database-pass=${PLUGIN_DB_PASSWORD}"
+    fi
   fi
 
 


### PR DESCRIPTION
Part of issue https://github.com/owncloud/files_classifier/issues/786

oC10 core PR https://github.com/owncloud/core/pull/36489 added `database-connection-string` for use when installing oC10 with Oracle DB. That PR added the logic to core drone CI to use that:
https://github.com/owncloud/core/pull/36489/files#diff-f42ddc060d71e10c4670605d3d4cd43b0053576cf67e7f1c87cc373779130094

But it was not added here in `owncloud-ci/core`

For some reason, oC10 core master with the daily tarball needs `database-connection-string` to be specified. Without that, the install gets the error documented in the attached issue.

So far, I don't know what changed in the daily tarball to cause this - but we might as well put this matching install code here, and dig into the underlying reason in the next day or so.